### PR TITLE
Fix: Allow tests to pass when no tests exist

### DIFF
--- a/main-website/package.json
+++ b/main-website/package.json
@@ -44,7 +44,7 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --passWithNoTests",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
Add --passWithNoTests flag to test script so CI/CD can succeed without test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)